### PR TITLE
Fix: ensure XNAT session is properly closed after every use

### DIFF
--- a/scripts/xnat_tagger.py
+++ b/scripts/xnat_tagger.py
@@ -52,22 +52,22 @@ def main():
 
     append_tag_digits = args.append_tag_digits == 'True'
 
-    tagger = Tagger(
+    with Tagger(
         args.xnat_alias,
         configs,
         args.target_modality,
         args.label,
         append_tag_digits,
         cache=args.cache
-    )
-    tagger.generate_updates()
+    ) as tagger:
+        tagger.generate_updates()
 
-    if args.output_file:
-        with open(args.output_file, 'w') as fo:
-            js = json.dumps(tagger.updates, indent=2)
-            fo.write(js)
-    if not args.dry_run:
-        tagger.apply_updates()
+        if args.output_file:
+            with open(args.output_file, 'w') as fo:
+                js = json.dumps(tagger.updates, indent=2)
+                fo.write(js)
+        if not args.dry_run:
+            tagger.apply_updates()
 
 if __name__ == '__main__':
     main()

--- a/xnattagger/__init__.py
+++ b/xnattagger/__init__.py
@@ -70,6 +70,13 @@ class Tagger:
         self.updates.clear()
         self.updates.update(filtered)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        yaxil.end_session(self.auth)
+        return False
+
     def apply_updates(self):
         self.upsert()
 


### PR DESCRIPTION
### Context

Over at Boston University, I have been working on an automatic QA workflow built on top of Harvard's XNAT tools. This workflow identifies a new MR session uploaded to our XNAT instance, tags the scans with `xnattager`, and then launches jobs on our HPC cluster to generate the QA reports with `boldqc`/`anatqc`. The problem I kept running into is that, when run at scale on 100s of MR sessions, our XNAT was left with 100s of user sessions that were never closed, causing my account to be locked out and my QA routines to fail. I initially thought this was due to `boldqc`/`anatqc`/`yaxil`, but I believe `xnattager` is the culprit.

### Problem

Previously, the yaxil session opened during Tagger initialization was never explicitly closed. This could leave dangling server-side sessions on XNAT.

### Summary

Adds `__enter__` and `__exit__` methods to the Tagger class, making it a context manager. Calls `yaxil.end_session()` in `__exit__` so the XNAT session is always closed, even if an error occurs mid-run. Updates `scripts/xnat_tagger.py` to instantiate Tagger via a with statement.