### PR TITLE
Bug fix: --append-tag-digits default

### DIFF
--- a/scripts/xnat_tagger.py
+++ b/scripts/xnat_tagger.py
@@ -34,7 +34,7 @@ def main():
     parser.add_argument('--config', required=True,
         help='Filters configuration file')
     parser.add_argument('--target-modality', nargs='+', required=True, type=str.lower)
-    parser.add_argument('--append-tag-digits', type=str, default=True)
+    parser.add_argument('--append-tag-digits', type=str, default='True')
     parser.add_argument('--project',
         help='XNAT project')
     parser.add_argument('-c', '--cache', action='store_true',


### PR DESCRIPTION
The default for the "--append-tag-digits" was not working properly since it is supposed to be type str but the actual default is a boolean. This small bug fix restores the default to work as intended -- to append digits by default if this flag is not set.